### PR TITLE
feat: support for code challenge and code verifier

### DIFF
--- a/docs/goiam.yaml
+++ b/docs/goiam.yaml
@@ -55,6 +55,12 @@ paths:
                 - description: The URL to redirect to after login
                   in: query
                   name: redirect_url
+                - description: Code challenge for PKCE. This required for public clients. For security reasons, only S256 is supported.
+                  in: query
+                  name: code_challenge
+                - description: Code verifier for PKCE. This required for public clients
+                  in: query
+                  name: code_verifier
             responses:
                 default:
                     content:
@@ -83,6 +89,12 @@ paths:
                   in: query
                   name: code
                   required: true
+                - description: The code verifier
+                  in: query
+                  name: code_verifier
+                - description: The client ID to be provided if code verifier is provided
+                  in: query
+                  name: client_id
             responses:
                 default:
                     content:

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -62,6 +62,8 @@ func InjectDefaultProviders(cnf config.AppConfig) (*Provider, error) {
 	// subscribe to client events for checking auth client
 	svcs.Clients.Subscribe(goiamuniverse.EventClientCreated, pvd)
 	svcs.Clients.Subscribe(goiamuniverse.EventClientUpdated, pvd)
+	svcs.Clients.Subscribe(goiamuniverse.EventClientCreated, svcs.Auth)
+	svcs.Clients.Subscribe(goiamuniverse.EventClientUpdated, svcs.Auth)
 
 	// creating default project if it doesn't exist
 	err = checkAndAddDefaultProject(svcs.Projects)

--- a/sdk/auth_token.go
+++ b/sdk/auth_token.go
@@ -7,4 +7,7 @@ type AuthToken struct {
 	RefreshToken   string    `json:"refresh_token"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	AuthProviderID string    `json:"auth_provider_id"`
+	CodeChallenge  string    `json:"code_challenge"`
+	CodeVerifier   string    `json:"code_verifier"`
+	ClientId       string    `json:"client_id"`
 }

--- a/services/auth/events.go
+++ b/services/auth/events.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/melvinodsa/go-iam/sdk"
+	"github.com/melvinodsa/go-iam/utils"
+	"github.com/melvinodsa/go-iam/utils/goiamuniverse"
+)
+
+func (s *service) HandleEvent(e utils.Event[sdk.Client]) {
+	switch e.Name() {
+	case goiamuniverse.EventClientCreated:
+		s.handleClientUpdates(e)
+	case goiamuniverse.EventClientUpdated:
+		s.handleClientUpdates(e)
+	default:
+		return
+	}
+
+}
+
+func (s *service) handleClientUpdates(e utils.Event[sdk.Client]) {
+	s.cacheClientSecret(context.Background(), e.Payload().Id, e.Payload().Secret)
+}

--- a/services/auth/helpers.go
+++ b/services/auth/helpers.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2/log"
+	"github.com/melvinodsa/go-iam/sdk"
+)
+
+func (s *service) cacheClientSecret(ctx context.Context, clientId string, secret string) {
+	s.cacheSvc.Set(ctx, fmt.Sprintf("client-%s", clientId), secret, time.Hour*24*365)
+}
+
+func (s *service) getClientSecret(ctx context.Context, clientId string) (string, error) {
+	secret, err := s.cacheSvc.Get(ctx, fmt.Sprintf("client-%s", clientId))
+	if err == nil {
+		return secret, nil
+	}
+	cl, err := s.clientSvc.Get(ctx, clientId, false)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get the client even from db: %w", err)
+	}
+	s.cacheSvc.Set(ctx, fmt.Sprintf("client-%s", clientId), cl.Secret, time.Hour*24*365)
+	return cl.Secret, nil
+}
+
+func (s *service) handlePrivateClient(ctx context.Context, clientId, clientSecret string) error {
+	secret, err := s.getClientSecret(ctx, clientId)
+	if err != nil {
+		return fmt.Errorf("error getting client secret: %w", err)
+	}
+	if secret != clientSecret {
+		return fmt.Errorf("invalid client secret")
+	}
+	return nil
+}
+
+func (s *service) handlePublicClient(clientId, codeVerifier string, token sdk.AuthToken) error {
+	// Implement public client handling logic here
+	if token.CodeChallenge != "S256" {
+		return fmt.Errorf("invalid code challenge")
+	}
+	calculatedVerifier := generateCodeChallengeS256(token.CodeVerifier)
+	// Verify the code verifier
+	if strings.Compare(calculatedVerifier, codeVerifier) != 0 {
+		log.Debugw("invalid code verifier", "calculated_verifier", calculatedVerifier, "code_verifier", codeVerifier)
+		return fmt.Errorf("invalid code verifier")
+	}
+	if strings.Compare(token.ClientId, clientId) != 0 {
+		return fmt.Errorf("invalid client id")
+	}
+	return nil
+}
+
+func generateCodeChallengeS256(codeVerifier string) string {
+	hash := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}

--- a/services/auth/service.go
+++ b/services/auth/service.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/melvinodsa/go-iam/sdk"
+	"github.com/melvinodsa/go-iam/utils"
 )
 
 type Service interface {
-	GetLoginUrl(ctx context.Context, clientId, authProviderId, state, redirectUrl string) (string, error)
+	GetLoginUrl(ctx context.Context, clientId, authProviderId, state, redirectUrl, codeChallenge, codeVerifier string) (string, error)
 	Redirect(ctx context.Context, code, state string) (*sdk.AuthRedirectResponse, error)
-	ClientCallback(ctx context.Context, code string) (*sdk.AuthVerifyCodeResponse, error)
+	ClientCallback(ctx context.Context, code, codeVerifier, clientId, clietSecret string) (*sdk.AuthVerifyCodeResponse, error)
 	GetIdentity(ctx context.Context, accessToken string) (*sdk.User, error)
+	HandleEvent(event utils.Event[sdk.Client])
 }


### PR DESCRIPTION
Now go iam supports public clients as well. While trying to doing login, the client needs to pass `code_challenge` and `code_verifier`. In the redirect step it gets `code_verifier` value which is Sha256 hash of the the original `code_verifier` provided during the login. api call. If code_verifier matches, the access token is granted. This enables the UI clients to authenticate without requiring a backend.