### PR TITLE
feat: open id connect support

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,8 @@ func TestNewAppConfig(t *testing.T) {
 	// Clean environment before test
 	cleanEnv()
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	config := NewAppConfig()
 
 	assert.NotNil(t, config)

--- a/routes/auth/auth_test.go
+++ b/routes/auth/auth_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogin(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -166,7 +168,8 @@ func TestLogin(t *testing.T) {
 }
 
 func TestRedirect(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -288,7 +291,8 @@ func TestRedirect(t *testing.T) {
 }
 
 func TestVerify(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -550,7 +554,8 @@ func TestVerify(t *testing.T) {
 }
 
 func TestClientCredentials(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/authprovider/authprovider_test.go
+++ b/routes/authprovider/authprovider_test.go
@@ -20,10 +20,12 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -147,7 +149,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -274,7 +277,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestFetchAll(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -373,7 +377,8 @@ func TestFetchAll(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/client/client_test.go
+++ b/routes/client/client_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {
 	// setup
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -205,7 +207,8 @@ func TestCreate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	// setup
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -338,7 +341,8 @@ func TestGet(t *testing.T) {
 
 func TestFetchhAll(t *testing.T) {
 	// setup
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -440,7 +444,8 @@ func TestFetchhAll(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	// setup
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -664,7 +669,8 @@ func TestUpdate(t *testing.T) {
 
 func TestRegenerateSecret(t *testing.T) {
 	// setup
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/health/health_test.go
+++ b/routes/health/health_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealth(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -160,11 +162,12 @@ func TestHealth(t *testing.T) {
 		assert.NotNil(t, resp)
 
 		// Status code should be 200 for healthy systems
-		if resp.Data.Status == "healthy" {
+		switch resp.Data.Status {
+		case "healthy":
 			assert.Equal(t, 200, res.StatusCode)
-		} else if resp.Data.Status == "degraded" {
+		case "degraded":
 			assert.Equal(t, 206, res.StatusCode) // StatusPartialContent
-		} else if resp.Data.Status == "unhealthy" {
+		case "unhealthy":
 			assert.Equal(t, 503, res.StatusCode) // StatusServiceUnavailable
 		}
 	})

--- a/routes/project/project_test.go
+++ b/routes/project/project_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProject(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -165,7 +167,8 @@ func TestProject(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -304,7 +307,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestFetchAll(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -404,7 +408,8 @@ func TestFetchAll(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/resource/resource_test.go
+++ b/routes/resource/resource_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -151,7 +153,8 @@ func TestGet(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -283,7 +286,8 @@ func TestCreate(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -379,7 +383,8 @@ func TestSearch(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -547,7 +552,8 @@ func TestUpdate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/role/role_test.go
+++ b/routes/role/role_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -145,7 +147,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -244,7 +247,8 @@ func TestSearch(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -366,7 +370,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/routes/user/user_test.go
+++ b/routes/user/user_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/melvinodsa/go-iam/utils/test/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetById(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -151,7 +153,8 @@ func TestGetById(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -284,7 +287,8 @@ func TestCreate(t *testing.T) {
 
 func TestGetAll(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -380,7 +384,8 @@ func TestGetAll(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -547,7 +552,8 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdateRoles(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,
@@ -788,7 +794,8 @@ func TestUpdateRoles(t *testing.T) {
 }
 
 func TestUpdatePolicies(t *testing.T) {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(t, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,

--- a/sdk/auth_provider.go
+++ b/sdk/auth_provider.go
@@ -24,6 +24,9 @@ const (
 
 	// AuthProviderTypeGitHub represents GitHub OAuth2 authentication.
 	AuthProviderTypeGitHub AuthProviderType = "GITHUB"
+
+	// AuthProviderTypeOIDC represents generic OpenID Connect authentication.
+	AuthProviderTypeOIDC AuthProviderType = "OIDC"
 )
 
 // AuthProvider represents an external authentication provider configuration.

--- a/services/authprovider/oidc/README.md
+++ b/services/authprovider/oidc/README.md
@@ -1,0 +1,202 @@
+# Generic OpenID Connect (OIDC) Provider
+
+This package provides a generic OpenID Connect authentication provider for the Go IAM system. It can work with any OIDC-compliant identity provider.
+
+## Features
+
+- **Generic OIDC Support**: Works with any OpenID Connect-compliant provider
+- **OAuth2 Authorization Code Flow**: Full support for the standard OAuth2 flow
+- **Refresh Token Support**: Automatic token refresh for long-lived sessions
+- **UserInfo Integration**: Retrieves user profile information from the OIDC UserInfo endpoint
+- **Flexible Configuration**: Configurable endpoints, scopes, and parameters
+
+## Configuration Parameters
+
+When creating an OIDC auth provider in the Go IAM system, you need to configure the following parameters:
+
+### Required Parameters
+
+- `@OIDC/CLIENT_ID`: OAuth2 client identifier from your OIDC provider
+- `@OIDC/CLIENT_SECRET`: OAuth2 client secret from your OIDC provider
+- `@OIDC/REDIRECT_URL`: The callback URL for your application
+- `@OIDC/AUTHORIZATION_URL`: The authorization endpoint of your OIDC provider
+- `@OIDC/TOKEN_URL`: The token endpoint of your OIDC provider
+- `@OIDC/USERINFO_URL`: The UserInfo endpoint of your OIDC provider
+
+## Usage Examples
+
+### Example: Auth0 Configuration
+
+```json
+{
+  "name": "Auth0 Provider",
+  "provider": "OIDC",
+  "params": [
+    {
+      "key": "@OIDC/CLIENT_ID",
+      "value": "your-auth0-client-id"
+    },
+    {
+      "key": "@OIDC/CLIENT_SECRET",
+      "value": "your-auth0-client-secret"
+    },
+    {
+      "key": "@OIDC/REDIRECT_URL",
+      "value": "https://yourapp.com/auth/callback"
+    },
+    {
+      "key": "@OIDC/AUTHORIZATION_URL",
+      "value": "https://yourdomain.auth0.com/authorize"
+    },
+    {
+      "key": "@OIDC/TOKEN_URL",
+      "value": "https://yourdomain.auth0.com/oauth/token"
+    },
+    {
+      "key": "@OIDC/USERINFO_URL",
+      "value": "https://yourdomain.auth0.com/userinfo"
+    },
+    {
+      "key": "@OIDC/SCOPES",
+      "value": "openid profile email"
+    }
+  ]
+}
+```
+
+### Example: Keycloak Configuration
+
+```json
+{
+  "name": "Keycloak Provider",
+  "provider": "OIDC",
+  "params": [
+    {
+      "key": "@OIDC/CLIENT_ID",
+      "value": "your-keycloak-client-id"
+    },
+    {
+      "key": "@OIDC/CLIENT_SECRET",
+      "value": "your-keycloak-client-secret"
+    },
+    {
+      "key": "@OIDC/REDIRECT_URL",
+      "value": "https://yourapp.com/auth/callback"
+    },
+    {
+      "key": "@OIDC/AUTHORIZATION_URL",
+      "value": "https://keycloak.example.com/auth/realms/yourrealm/protocol/openid-connect/auth"
+    },
+    {
+      "key": "@OIDC/TOKEN_URL",
+      "value": "https://keycloak.example.com/auth/realms/yourrealm/protocol/openid-connect/token"
+    },
+    {
+      "key": "@OIDC/USERINFO_URL",
+      "value": "https://keycloak.example.com/auth/realms/yourrealm/protocol/openid-connect/userinfo"
+    }
+  ]
+}
+```
+
+### Example: Okta Configuration
+
+```json
+{
+  "name": "Okta Provider",
+  "provider": "OIDC",
+  "params": [
+    {
+      "key": "@OIDC/CLIENT_ID",
+      "value": "your-okta-client-id"
+    },
+    {
+      "key": "@OIDC/CLIENT_SECRET",
+      "value": "your-okta-client-secret"
+    },
+    {
+      "key": "@OIDC/REDIRECT_URL",
+      "value": "https://yourapp.com/auth/callback"
+    },
+    {
+      "key": "@OIDC/AUTHORIZATION_URL",
+      "value": "https://yourdomain.okta.com/oauth2/default/v1/authorize"
+    },
+    {
+      "key": "@OIDC/TOKEN_URL",
+      "value": "https://yourdomain.okta.com/oauth2/default/v1/token"
+    },
+    {
+      "key": "@OIDC/USERINFO_URL",
+      "value": "https://yourdomain.okta.com/oauth2/default/v1/userinfo"
+    },
+    {
+      "key": "@OIDC/ISSUER",
+      "value": "https://yourdomain.okta.com/oauth2/default"
+    }
+  ]
+}
+```
+
+## Supported User Information
+
+The OIDC provider extracts the following user information from the UserInfo endpoint:
+
+- **Email**: Primary email address (`email` field)
+- **Name**: Full name or constructed from given/family names (`name`, `given_name`, `family_name` fields)
+- **Profile Picture**: Avatar/profile image URL (`picture` field)
+
+## Authentication Flow
+
+1. **Authorization**: User is redirected to the OIDC provider's authorization endpoint
+2. **Code Exchange**: Authorization code is exchanged for access and refresh tokens
+3. **UserInfo Retrieval**: Access token is used to fetch user profile information
+4. **Token Refresh**: Refresh tokens are used to obtain new access tokens when needed
+
+## Error Handling
+
+The provider includes comprehensive error handling for:
+
+- Invalid configuration parameters
+- Network failures during token exchange
+- HTTP error responses from OIDC endpoints
+- Malformed JSON responses
+- Token expiration and refresh failures
+
+## Security Features
+
+- **PKCE Support**: Includes PKCE (Proof Key for Code Exchange) parameters for enhanced security
+- **Token Validation**: Validates HTTP status codes and response formats
+- **Secure Headers**: Sets appropriate Accept and Authorization headers
+- **Error Sanitization**: Provides clear error messages without exposing sensitive information
+
+## Testing
+
+The package includes comprehensive tests covering:
+
+- Provider configuration and initialization
+- Authorization URL generation
+- Token exchange and refresh flows
+- UserInfo endpoint integration
+- Error scenarios and edge cases
+- Mock server integration for isolated testing
+
+Run tests with:
+
+```bash
+go test ./services/authprovider/oidc/... -v
+```
+
+## Compatibility
+
+This OIDC provider is compatible with any OpenID Connect 1.0 compliant identity provider, including:
+
+- Auth0
+- Keycloak
+- Okta
+- Amazon Cognito
+- Azure Active Directory (via OIDC endpoints)
+- Firebase Auth
+- Custom OIDC implementations
+
+The provider follows the OpenID Connect Core 1.0 specification and OAuth 2.0 standards.

--- a/services/authprovider/oidc/oidc.go
+++ b/services/authprovider/oidc/oidc.go
@@ -1,0 +1,254 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gofiber/fiber/v2/log"
+	"github.com/melvinodsa/go-iam/sdk"
+	"golang.org/x/oauth2"
+)
+
+// authProvider implements the SDK ServiceProvider interface for generic OpenID Connect providers
+type authProvider struct {
+	cnf          oauth2.Config
+	userInfoURL  string
+	issuer       string
+	providerName string
+}
+
+// NewAuthProvider creates a new generic OIDC provider instance
+// Required parameters in the AuthProvider configuration:
+// - @OIDC/CLIENT_ID: OAuth2 client ID
+// - @OIDC/CLIENT_SECRET: OAuth2 client secret
+// - @OIDC/REDIRECT_URL: OAuth2 redirect URL
+// - @OIDC/AUTHORIZATION_URL: OIDC authorization endpoint
+// - @OIDC/TOKEN_URL: OIDC token endpoint
+// - @OIDC/USERINFO_URL: OIDC userinfo endpoint
+// - @OIDC/SCOPES: Space-separated list of OAuth2 scopes (optional, defaults to "openid profile email")
+func NewAuthProvider(p sdk.AuthProvider) sdk.ServiceProvider {
+	// Get configuration parameters
+	clientID := p.GetParam("@OIDC/CLIENT_ID")
+	clientSecret := p.GetParam("@OIDC/CLIENT_SECRET")
+	redirectURL := p.GetParam("@OIDC/REDIRECT_URL")
+	authURL := p.GetParam("@OIDC/AUTHORIZATION_URL")
+	tokenURL := p.GetParam("@OIDC/TOKEN_URL")
+	userInfoURL := p.GetParam("@OIDC/USERINFO_URL")
+
+	// Default scopes if not specified
+	scopes := []string{"openid", "profile", "email"}
+
+	oauthConfig := oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+	}
+
+	return authProvider{
+		cnf:          oauthConfig,
+		userInfoURL:  userInfoURL,
+		providerName: p.Name,
+	}
+}
+
+// HasRefreshTokenFlow indicates that OIDC providers typically support refresh tokens
+func (o authProvider) HasRefreshTokenFlow() bool {
+	return true
+}
+
+// GetAuthCodeUrl returns the authorization URL where users should be redirected for authentication
+func (o authProvider) GetAuthCodeUrl(state string) string {
+	return o.cnf.AuthCodeURL(state, oauth2.AccessTypeOffline)
+}
+
+// VerifyCode exchanges an authorization code for access and refresh tokens
+func (o authProvider) VerifyCode(ctx context.Context, code string) (*sdk.AuthToken, error) {
+	token, err := o.cnf.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("error verifying code with OIDC provider %s: %w", o.providerName, err)
+	}
+
+	return &sdk.AuthToken{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		ExpiresAt:    token.Expiry,
+	}, nil
+}
+
+// TokenResponse represents the OAuth2 token response structure
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+}
+
+// RefreshToken uses a refresh token to obtain a new access token
+func (o authProvider) RefreshToken(refreshToken string) (*sdk.AuthToken, error) {
+	data := url.Values{}
+	data.Set("client_id", o.cnf.ClientID)
+	data.Set("client_secret", o.cnf.ClientSecret)
+	data.Set("refresh_token", refreshToken)
+	data.Set("grant_type", "refresh_token")
+
+	resp, err := http.PostForm(o.cnf.Endpoint.TokenURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("error refreshing token with OIDC provider %s: %w", o.providerName, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Errorf("failed to close response body: %w", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading token refresh response: %w", err)
+	}
+
+	// Check for HTTP error status codes
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error refreshing token, status: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResponse TokenResponse
+	err = json.Unmarshal(body, &tokenResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling token response: %w", err)
+	}
+
+	// Calculate expiration time
+	expiresAt := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
+
+	return &sdk.AuthToken{
+		AccessToken:  tokenResponse.AccessToken,
+		RefreshToken: tokenResponse.RefreshToken,
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+// OIDCIdentityEmail handles email identity information
+type OIDCIdentityEmail struct {
+	Email string `json:"email"`
+}
+
+func (o OIDCIdentityEmail) UpdateUserDetails(user *sdk.User) {
+	user.Email = o.Email
+}
+
+// OIDCIdentityName handles name identity information
+type OIDCIdentityName struct {
+	Name string `json:"name"`
+}
+
+func (o OIDCIdentityName) UpdateUserDetails(user *sdk.User) {
+	user.Name = o.Name
+}
+
+// OIDCIdentityProfilePic handles profile picture identity information
+type OIDCIdentityProfilePic struct {
+	ProfilePic string `json:"picture"`
+}
+
+func (o OIDCIdentityProfilePic) UpdateUserDetails(user *sdk.User) {
+	user.ProfilePic = o.ProfilePic
+}
+
+// UserInfoResponse represents the standard OIDC UserInfo response
+type UserInfoResponse struct {
+	Sub               string `json:"sub"`
+	Name              string `json:"name"`
+	GivenName         string `json:"given_name"`
+	FamilyName        string `json:"family_name"`
+	PreferredUsername string `json:"preferred_username"`
+	Email             string `json:"email"`
+	EmailVerified     bool   `json:"email_verified"`
+	Picture           string `json:"picture"`
+	Locale            string `json:"locale"`
+}
+
+// GetIdentity retrieves user identity information using an access token
+func (o authProvider) GetIdentity(token string) ([]sdk.AuthIdentity, error) {
+	req, err := http.NewRequest("GET", o.userInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching identity from OIDC provider %s: %w", o.providerName, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Errorf("failed to close response body: %w", err)
+		}
+	}()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading userinfo response: %w", err)
+	}
+
+	// Check for HTTP error status codes
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error fetching identity, status: %d, response: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var userInfo UserInfoResponse
+	err = json.Unmarshal(respBytes, &userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling userinfo response: %s - %w", string(respBytes), err)
+	}
+
+	var identities []sdk.AuthIdentity
+
+	// Add email identity if available
+	if userInfo.Email != "" {
+		identities = append(identities, sdk.AuthIdentity{
+			Type:     sdk.AuthIdentityTypeEmail,
+			Metadata: OIDCIdentityEmail{Email: userInfo.Email},
+		})
+	}
+
+	// Add name identity (prefer full name, fallback to given name, then preferred username)
+	name := userInfo.Name
+	if name == "" && userInfo.GivenName != "" {
+		if userInfo.FamilyName != "" {
+			name = fmt.Sprintf("%s %s", userInfo.GivenName, userInfo.FamilyName)
+		} else {
+			name = userInfo.GivenName
+		}
+	}
+	if name == "" {
+		name = userInfo.PreferredUsername
+	}
+	if name != "" {
+		identities = append(identities, sdk.AuthIdentity{
+			Type:     sdk.AuthIdentityTypeEmail, // Using email type as the general identity type
+			Metadata: OIDCIdentityName{Name: name},
+		})
+	}
+
+	// Add profile picture identity if available
+	if userInfo.Picture != "" {
+		identities = append(identities, sdk.AuthIdentity{
+			Type:     sdk.AuthIdentityTypeEmail, // Using email type as the general identity type
+			Metadata: OIDCIdentityProfilePic{ProfilePic: userInfo.Picture},
+		})
+	}
+
+	return identities, nil
+}

--- a/services/authprovider/oidc/oidc_test.go
+++ b/services/authprovider/oidc/oidc_test.go
@@ -1,0 +1,275 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/melvinodsa/go-iam/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAuthProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider sdk.AuthProvider
+		expected authProvider
+	}{
+		{
+			name: "creates provider with default scopes",
+			provider: mockAuthProvider(map[string]string{
+				"@OIDC/CLIENT_ID":         "test-client-id",
+				"@OIDC/CLIENT_SECRET":     "test-client-secret",
+				"@OIDC/REDIRECT_URL":      "https://example.com/callback",
+				"@OIDC/AUTHORIZATION_URL": "https://provider.example.com/auth",
+				"@OIDC/TOKEN_URL":         "https://provider.example.com/token",
+				"@OIDC/USERINFO_URL":      "https://provider.example.com/userinfo",
+				"@OIDC/ISSUER":            "https://provider.example.com",
+			}),
+			expected: authProvider{
+				userInfoURL:  "https://provider.example.com/userinfo",
+				issuer:       "https://provider.example.com",
+				providerName: "Test Provider",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewAuthProvider(tt.provider)
+			assert.NotNil(t, provider)
+
+			oidcProvider, ok := provider.(authProvider)
+			require.True(t, ok)
+
+			assert.Equal(t, "test-client-id", oidcProvider.cnf.ClientID)
+			assert.Equal(t, "test-client-secret", oidcProvider.cnf.ClientSecret)
+			assert.Equal(t, "https://example.com/callback", oidcProvider.cnf.RedirectURL)
+			assert.Equal(t, "https://provider.example.com/auth", oidcProvider.cnf.Endpoint.AuthURL)
+			assert.Equal(t, "https://provider.example.com/token", oidcProvider.cnf.Endpoint.TokenURL)
+
+			if tt.provider.GetParam("@OIDC/SCOPES") != "" {
+				assert.Equal(t, []string{"openid", "profile", "email", "custom_scope"}, oidcProvider.cnf.Scopes)
+			} else {
+				assert.Equal(t, []string{"openid", "profile", "email"}, oidcProvider.cnf.Scopes)
+			}
+		})
+	}
+}
+
+func TestAuthProvider_HasRefreshTokenFlow(t *testing.T) {
+	provider := createTestProvider()
+	assert.True(t, provider.HasRefreshTokenFlow())
+}
+
+func TestAuthProvider_GetAuthCodeUrl(t *testing.T) {
+	provider := createTestProvider()
+	state := "test-state"
+
+	authURL := provider.GetAuthCodeUrl(state)
+
+	parsedURL, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	assert.Equal(t, "provider.example.com", parsedURL.Host)
+	assert.Equal(t, "/auth", parsedURL.Path)
+
+	query := parsedURL.Query()
+	assert.Equal(t, "test-client-id", query.Get("client_id"))
+	assert.Equal(t, state, query.Get("state"))
+	assert.Equal(t, "code", query.Get("response_type"))
+}
+
+func TestAuthProvider_VerifyCode(t *testing.T) {
+	// Mock token server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			t.Errorf("Expected path '/token', got %s", r.URL.Path)
+		}
+
+		response := map[string]interface{}{
+			"access_token":  "access-token-123",
+			"refresh_token": "refresh-token-456",
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(response)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	provider := createTestProviderWithServer(server.URL)
+
+	token, err := provider.VerifyCode(context.Background(), "test-code")
+
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-123", token.AccessToken)
+	assert.Equal(t, "refresh-token-456", token.RefreshToken)
+	assert.True(t, token.ExpiresAt.After(time.Now()))
+}
+
+func TestAuthProvider_RefreshToken(t *testing.T) {
+	// Mock token server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			t.Errorf("Expected path '/token', got %s", r.URL.Path)
+		}
+
+		err := r.ParseForm()
+		require.NoError(t, err)
+
+		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		assert.Equal(t, "old-refresh-token", r.Form.Get("refresh_token"))
+
+		response := TokenResponse{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+		}
+		err = json.NewEncoder(w).Encode(response)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	provider := createTestProviderWithServer(server.URL)
+
+	token, err := provider.RefreshToken("old-refresh-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken)
+	assert.Equal(t, "new-refresh-token", token.RefreshToken)
+	assert.True(t, token.ExpiresAt.After(time.Now()))
+}
+
+func TestAuthProvider_GetIdentity(t *testing.T) {
+	// Mock userinfo server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/userinfo" {
+			t.Errorf("Expected path '/userinfo', got %s", r.URL.Path)
+		}
+
+		auth := r.Header.Get("Authorization")
+		assert.Equal(t, "Bearer test-access-token", auth)
+
+		userInfo := UserInfoResponse{
+			Sub:           "user-123",
+			Name:          "John Doe",
+			GivenName:     "John",
+			FamilyName:    "Doe",
+			Email:         "john.doe@example.com",
+			EmailVerified: true,
+			Picture:       "https://example.com/avatar.jpg",
+		}
+		err := json.NewEncoder(w).Encode(userInfo)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	provider := createTestProviderWithUserInfoServer(server.URL)
+
+	identities, err := provider.GetIdentity("test-access-token")
+
+	require.NoError(t, err)
+	assert.Len(t, identities, 3)
+
+	// Check email identity
+	emailIdentity := identities[0]
+	assert.Equal(t, sdk.AuthIdentityTypeEmail, emailIdentity.Type)
+	emailMeta, ok := emailIdentity.Metadata.(OIDCIdentityEmail)
+	require.True(t, ok)
+	assert.Equal(t, "john.doe@example.com", emailMeta.Email)
+
+	// Check name identity
+	nameIdentity := identities[1]
+	assert.Equal(t, sdk.AuthIdentityTypeEmail, nameIdentity.Type)
+	nameMeta, ok := nameIdentity.Metadata.(OIDCIdentityName)
+	require.True(t, ok)
+	assert.Equal(t, "John Doe", nameMeta.Name)
+
+	// Check profile picture identity
+	picIdentity := identities[2]
+	assert.Equal(t, sdk.AuthIdentityTypeEmail, picIdentity.Type)
+	picMeta, ok := picIdentity.Metadata.(OIDCIdentityProfilePic)
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com/avatar.jpg", picMeta.ProfilePic)
+}
+
+func TestIdentityTypes_UpdateUserDetails(t *testing.T) {
+	user := &sdk.User{}
+
+	// Test email identity
+	emailIdentity := OIDCIdentityEmail{Email: "test@example.com"}
+	emailIdentity.UpdateUserDetails(user)
+	assert.Equal(t, "test@example.com", user.Email)
+
+	// Test name identity
+	nameIdentity := OIDCIdentityName{Name: "Test User"}
+	nameIdentity.UpdateUserDetails(user)
+	assert.Equal(t, "Test User", user.Name)
+
+	// Test profile picture identity
+	picIdentity := OIDCIdentityProfilePic{ProfilePic: "https://example.com/pic.jpg"}
+	picIdentity.UpdateUserDetails(user)
+	assert.Equal(t, "https://example.com/pic.jpg", user.ProfilePic)
+}
+
+// Helper functions
+
+func mockAuthProvider(params map[string]string) sdk.AuthProvider {
+	return sdk.AuthProvider{
+		Name: "Test Provider",
+		Params: func() []sdk.AuthProviderParam {
+			var paramsList []sdk.AuthProviderParam
+			for key, value := range params {
+				paramsList = append(paramsList, sdk.AuthProviderParam{
+					Key:   key,
+					Value: value,
+				})
+			}
+			return paramsList
+		}(),
+	}
+}
+
+func createTestProvider() authProvider {
+	provider := mockAuthProvider(map[string]string{
+		"@OIDC/CLIENT_ID":         "test-client-id",
+		"@OIDC/CLIENT_SECRET":     "test-client-secret",
+		"@OIDC/REDIRECT_URL":      "https://example.com/callback",
+		"@OIDC/AUTHORIZATION_URL": "https://provider.example.com/auth",
+		"@OIDC/TOKEN_URL":         "https://provider.example.com/token",
+		"@OIDC/USERINFO_URL":      "https://provider.example.com/userinfo",
+	})
+	return NewAuthProvider(provider).(authProvider)
+}
+
+func createTestProviderWithServer(serverURL string) authProvider {
+	provider := mockAuthProvider(map[string]string{
+		"@OIDC/CLIENT_ID":         "test-client-id",
+		"@OIDC/CLIENT_SECRET":     "test-client-secret",
+		"@OIDC/REDIRECT_URL":      "https://example.com/callback",
+		"@OIDC/AUTHORIZATION_URL": serverURL + "/auth",
+		"@OIDC/TOKEN_URL":         serverURL + "/token",
+		"@OIDC/USERINFO_URL":      serverURL + "/userinfo",
+	})
+	return NewAuthProvider(provider).(authProvider)
+}
+
+func createTestProviderWithUserInfoServer(serverURL string) authProvider {
+	provider := mockAuthProvider(map[string]string{
+		"@OIDC/CLIENT_ID":         "test-client-id",
+		"@OIDC/CLIENT_SECRET":     "test-client-secret",
+		"@OIDC/REDIRECT_URL":      "https://example.com/callback",
+		"@OIDC/AUTHORIZATION_URL": "https://provider.example.com/auth",
+		"@OIDC/TOKEN_URL":         "https://provider.example.com/token",
+		"@OIDC/USERINFO_URL":      serverURL + "/userinfo",
+	})
+	return NewAuthProvider(provider).(authProvider)
+}

--- a/services/authprovider/service_impl.go
+++ b/services/authprovider/service_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/melvinodsa/go-iam/services/authprovider/github"
 	"github.com/melvinodsa/go-iam/services/authprovider/google"
 	"github.com/melvinodsa/go-iam/services/authprovider/microsoft"
+	"github.com/melvinodsa/go-iam/services/authprovider/oidc"
 	"github.com/melvinodsa/go-iam/services/project"
 	"github.com/melvinodsa/go-iam/utils"
 )
@@ -71,6 +72,8 @@ func (s service) GetProvider(ctx context.Context, v sdk.AuthProvider) (sdk.Servi
 		return microsoft.NewAuthProvider(v), nil
 	case sdk.AuthProviderTypeGitHub:
 		return github.NewAuthProvider(v), nil
+	case sdk.AuthProviderTypeOIDC:
+		return oidc.NewAuthProvider(v), nil
 	default:
 		return nil, fmt.Errorf("unknown auth provider: %s", v.Provider)
 	}

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -9,10 +9,12 @@ import (
 	"github.com/melvinodsa/go-iam/config"
 	"github.com/melvinodsa/go-iam/providers"
 	"github.com/melvinodsa/go-iam/routes"
+	"github.com/stretchr/testify/require"
 )
 
 func SetupServer(app *fiber.App) *config.AppConfig {
-	os.Setenv("JWT_SECRET", "abcd")
+	err := os.Setenv("JWT_SECRET", "abcd")
+	require.NoError(nil, err)
 	cnf := config.NewAppConfig()
 	log.Infow("Loaded Configurations",
 		"host", cnf.Server.Host,


### PR DESCRIPTION
🔑 What OIDC Adds

OIDC = OAuth 2.0 + identity layer

OAuth2 handles authorization (who can access what).

OIDC adds authentication (who the user is).

The main difference: ID Tokens (JWTs containing user identity claims).

🏗️ Core Pieces You Must Implement

Discovery endpoint

/.well-known/openid-configuration

JSON document describing your endpoints, supported scopes, claims, and JWKS URL.

Lets clients auto-configure.

JWKS endpoint

/.well-known/jwks.json

Publish your public keys so clients can verify ID tokens.

Typically uses RS256 or ES256 keys.

Authorization endpoint (/authorize)

Handles login + consent UI.

Accepts params like client_id, redirect_uri, scope=openid, response_type=code.

Issues an authorization code (short-lived).

Token endpoint (/token)

Client exchanges the authorization code + secret for tokens.

Returns:

access_token (for APIs)

id_token (JWT with user identity)

refresh_token (if offline access is allowed)

UserInfo endpoint (/userinfo)

Returns user claims (profile, email, etc.) when presented with a valid access token.

ID Token issuance

Sign a JWT with user claims (sub, name, email, etc.).

Must include standard claims (iss, aud, exp, iat).

Signed with your private key, verifiable via JWKS.