### PR TITLE
support for force fetch

### DIFF
--- a/middlewares/auth/auth.go
+++ b/middlewares/auth/auth.go
@@ -138,7 +138,7 @@ func (m *Middlewares) GetUser(c *fiber.Ctx) (*sdk.User, error) {
 		return nil, errors.New("`Bearer` token not found in header")
 	}
 
-	user, err := m.authSvc.GetIdentity(c.Context(), token)
+	user, err := m.authSvc.GetIdentity(c.Context(), token, c.QueryBool("force_fetch", false))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch identity: %w", err)
 	}

--- a/middlewares/auth/auth_test.go
+++ b/middlewares/auth/auth_test.go
@@ -126,7 +126,7 @@ func TestMiddlewares_User_Success(t *testing.T) {
 	app, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
 	testUser := createTestUser()
-	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token").Return(testUser, nil)
+	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token", mock.Anything).Return(testUser, nil)
 
 	// Create a test route
 	app.Get("/test", middlewares.User, func(c *fiber.Ctx) error {
@@ -167,7 +167,7 @@ func TestMiddlewares_User_NoAuthClient(t *testing.T) {
 func TestMiddlewares_User_AuthError(t *testing.T) {
 	app, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
-	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token").Return(nil, errors.New("invalid token"))
+	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token", mock.Anything).Return(nil, errors.New("invalid token"))
 
 	app.Get("/test", middlewares.User, func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"message": "success"})
@@ -188,7 +188,7 @@ func TestMiddlewares_DashboardUser_Success(t *testing.T) {
 	app, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
 	testUser := createTestUser()
-	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token").Return(testUser, nil)
+	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token", mock.Anything).Return(testUser, nil)
 
 	app.Get("/dashboard", middlewares.DashboardUser, func(c *fiber.Ctx) error {
 		user := c.Context().UserValue(sdk.UserTypeVal).(*sdk.User)
@@ -225,7 +225,7 @@ func TestMiddlewares_DashboardUser_NoAuthClient(t *testing.T) {
 func TestMiddlewares_DashboardUser_AuthError(t *testing.T) {
 	app, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
-	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token").Return(nil, errors.New("invalid token"))
+	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token", mock.Anything).Return(nil, errors.New("invalid token"))
 
 	app.Get("/dashboard", middlewares.DashboardUser, func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"message": "success"})
@@ -246,7 +246,7 @@ func TestMiddlewares_GetUser_Success(t *testing.T) {
 	_, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
 	testUser := createTestUser()
-	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token").Return(testUser, nil)
+	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token", mock.Anything).Return(testUser, nil)
 
 	// Test GetUser indirectly through middleware since direct testing requires internal context
 	app := fiber.New()
@@ -333,7 +333,7 @@ func TestMiddlewares_GetUser_InvalidAuthHeader(t *testing.T) {
 func TestMiddlewares_GetUser_AuthServiceError(t *testing.T) {
 	_, mockAuthSvc, mockClientSvc, middlewares := setupTestAppWithAuthClient()
 
-	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token").Return(nil, errors.New("token expired"))
+	mockAuthSvc.On("GetIdentity", mock.Anything, "invalid-token", mock.Anything).Return(nil, errors.New("token expired"))
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -396,7 +396,7 @@ func BenchmarkMiddlewares_GetUser(b *testing.B) {
 	_, mockAuthSvc, _, middlewares := setupTestAppWithAuthClient()
 
 	testUser := createTestUser()
-	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token").Return(testUser, nil)
+	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token", mock.Anything).Return(testUser, nil)
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -423,7 +423,7 @@ func BenchmarkMiddlewares_User(b *testing.B) {
 	app, mockAuthSvc, _, middlewares := setupTestAppWithAuthClient()
 
 	testUser := createTestUser()
-	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token").Return(testUser, nil)
+	mockAuthSvc.On("GetIdentity", mock.Anything, "valid-token", mock.Anything).Return(testUser, nil)
 
 	app.Get("/test", middlewares.User, func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"message": "success"})

--- a/routes/me/me.go
+++ b/routes/me/me.go
@@ -24,6 +24,14 @@ func MeRoute(router fiber.Router, basePath string) {
 			Description: "User fetched successfully",
 			Content:     new(sdk.UserResponse),
 		},
+		Parameters: []docs.ApiParameter{
+			{
+				Name:        "force_fetch",
+				In:          "query",
+				Description: "Force fetch user information",
+				Required:    false,
+			},
+		},
 		Tags:                 routeTags,
 		ProjectIDNotRequired: true,
 	})
@@ -65,6 +73,14 @@ func DashboardMeRoute(router fiber.Router, basePath string, prv *providers.Provi
 		Response: &docs.ApiResponse{
 			Description: "User fetched successfully",
 			Content:     new(sdk.DashboardUserResponse),
+		},
+		Parameters: []docs.ApiParameter{
+			{
+				Name:        "force_fetch",
+				In:          "query",
+				Description: "Force fetch user information",
+				Required:    false,
+			},
 		},
 		Tags:                 routeTags,
 		ProjectIDNotRequired: true,

--- a/services/auth/service.go
+++ b/services/auth/service.go
@@ -11,7 +11,7 @@ type Service interface {
 	GetLoginUrl(ctx context.Context, clientId, authProviderId, state, redirectUrl, codeChallengeMethod, codeChallenge string) (string, error)
 	Redirect(ctx context.Context, code, state string) (*sdk.AuthRedirectResponse, error)
 	ClientCallback(ctx context.Context, code, codeChallenge, clientId, clietSecret string) (*sdk.AuthVerifyCodeResponse, error)
-	GetIdentity(ctx context.Context, accessToken string) (*sdk.User, error)
+	GetIdentity(ctx context.Context, accessToken string, forceFetch bool) (*sdk.User, error)
 	ClientCredentials(ctx context.Context, clientId, clientSecret string) (*sdk.AuthVerifyCodeResponse, error)
 	HandleEvent(event utils.Event[sdk.Client])
 }

--- a/services/auth/service_impl.go
+++ b/services/auth/service_impl.go
@@ -168,7 +168,7 @@ func (s service) ClientCallback(ctx context.Context, code, codeChallenge, client
 
 }
 
-func (s service) GetIdentity(ctx context.Context, accessToken string) (*sdk.User, error) {
+func (s service) GetIdentity(ctx context.Context, accessToken string, forceFetch bool) (*sdk.User, error) {
 	/*
 	 * get id from jwt access token
 	 * get the access token from cache
@@ -183,10 +183,13 @@ func (s service) GetIdentity(ctx context.Context, accessToken string) (*sdk.User
 		return nil, fmt.Errorf("error getting the access token id from claims")
 	}
 
-	usr, err := s.getUserFromCache(ctx, accessToken)
-	if err == nil && usr != nil {
-		log.Debugf("fetched user records from cache - %s", usr.Id)
-		return usr, nil
+	var usr *sdk.User
+	if !forceFetch {
+		usr, err = s.getUserFromCache(ctx, accessToken)
+		if err == nil && usr != nil {
+			log.Debugf("fetched user records from cache - %s", usr.Id)
+			return usr, nil
+		}
 	}
 
 	token, err := s.getAccessTokenFromCache(ctx, accessTokenId)

--- a/services/auth/service_impl_test.go
+++ b/services/auth/service_impl_test.go
@@ -2120,7 +2120,7 @@ func TestGetIdentity(t *testing.T) {
 
 			tt.setupMocks()
 
-			user, err := svc.GetIdentity(ctx, tt.accessToken)
+			user, err := svc.GetIdentity(ctx, tt.accessToken, false)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/utils/test/services/auth.go
+++ b/utils/test/services/auth.go
@@ -34,8 +34,8 @@ func (m *MockAuthService) ClientCallback(ctx context.Context, code, codeChalleng
 	return args.Get(0).(*sdk.AuthVerifyCodeResponse), args.Error(1)
 }
 
-func (m *MockAuthService) GetIdentity(ctx context.Context, token string) (*sdk.User, error) {
-	args := m.Called(ctx, token)
+func (m *MockAuthService) GetIdentity(ctx context.Context, token string, forceFetch bool) (*sdk.User, error) {
+	args := m.Called(ctx, token, forceFetch)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}


### PR DESCRIPTION
If `force_fetch` is specified in the authenticated apis, it will automatically force fetch the user identity and not rely on cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional force_fetch query parameter to the Me and Dashboard Me endpoints, allowing clients to bypass caching and retrieve the latest user information.

- Documentation
  - Updated API documentation for the Me and Dashboard Me endpoints to describe the new force_fetch query parameter, including its usage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->