### PR TITLE
enable resource when created

### DIFF
--- a/services/resource/store_impl.go
+++ b/services/resource/store_impl.go
@@ -102,6 +102,7 @@ func (s store) Create(ctx context.Context, resource *sdk.Resource) (string, erro
 	resource.ID = id
 	t := time.Now()
 	resource.CreatedAt = &t
+	resource.Enabled = true
 	d := fromSdkToModel(*resource)
 	md := models.GetResourceModel()
 	_, err := s.db.InsertOne(ctx, md, d)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created resources are now enabled by default, making them immediately usable after creation without manual activation.
  * Streamlines setup by removing a post-creation step, improving efficiency for provisioning and onboarding workflows.
  * Existing resources are unaffected; their current enabled/disabled status remains unchanged.
  * No configuration changes or migrations required to benefit from this behavior; it applies automatically to all new resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->