### PR TITLE
create service account if and only if the service account email is not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,42 @@ docker compose up -d
 - API: [http://localhost:3000](http://localhost:3000)
 - API Docs: [http://localhost:3000/docs](http://localhost:3000/docs)
 
+## 🧪 Testing
+
+### Running Tests
+
+Due to the extensive test suite in this project, it's important to use the correct testing command to avoid test caching issues that might cause local tests to pass while CI/CD fails.
+
+**Use this command for reliable testing:**
+
+```bash
+go test -count=1 ./... -v --race -cover
+```
+
+**Flags explanation:**
+
+- `-count=1`: Disables test result caching to ensure fresh test runs
+- `./...`: Runs tests for all packages recursively
+- `-v`: Verbose output showing individual test results
+- `--race`: Enables race condition detection
+- `-cover`: Shows test coverage information
+
+**Why `-count=1` is important:**
+
+- With many tests, Go may cache results and show false positives locally
+- CI/CD environments don't use cached results, leading to inconsistencies
+- This flag ensures your local testing matches CI/CD behavior
+
+### Running Specific Test Suites
+
+```bash
+# Test specific package
+go test -count=1 ./services/user -v --race -cover
+
+# Test specific function
+go test -count=1 ./services/user -v --race -cover -run TestCopyUserResources
+```
+
 ## 📦 Environment Variables
 
 Some important environment variables used in `.env`:

--- a/services/client/service_impl.go
+++ b/services/client/service_impl.go
@@ -81,6 +81,7 @@ func (s service) Create(ctx context.Context, client *sdk.Client) error {
 		return fmt.Errorf("error while creating client secret: %w", err)
 	}
 	client.Secret = sec
+	// we does the secret hasing inside the store create method
 	err = s.s.Create(ctx, client)
 	if err != nil {
 		return fmt.Errorf("error while creating client: %w", err)
@@ -90,9 +91,11 @@ func (s service) Create(ctx context.Context, client *sdk.Client) error {
 		return fmt.Errorf("error hashing client secret: %w", err)
 	}
 	client.Secret = hashedSec
-	err = s.createAndLinkServiceAccountUser(ctx, client, client.ServiceAccountEmail)
-	if err != nil {
-		return fmt.Errorf("failed to create service account user: %w", err)
+	if len(client.ServiceAccountEmail) > 0 {
+		err = s.createAndLinkServiceAccountUser(ctx, client, client.ServiceAccountEmail)
+		if err != nil {
+			return fmt.Errorf("failed to create service account user: %w", err)
+		}
 	}
 	client.Secret = sec // return the plain secret only during creation
 	s.Emit(newEvent(ctx, goiamuniverse.EventClientCreated, *client, middlewares.GetMetadata(ctx)))

--- a/services/client/service_impl_test.go
+++ b/services/client/service_impl_test.go
@@ -126,7 +126,6 @@ func TestService_GetAll_Success(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-
 func TestService_Get_Success(t *testing.T) {
 	mockStore := &MockStore{}
 	mockProjectService := &services.MockProjectService{}
@@ -196,6 +195,42 @@ func TestService_Create_Success(t *testing.T) {
 		Name:        "Test Client",
 		Description: "Test Description",
 		ProjectId:   "project1",
+	}
+
+	// We expect the store to be called with the client having a generated secret
+	mockStore.On("Create", ctx, mock.MatchedBy(func(c *sdk.Client) bool {
+		return c.Name == "Test Client" &&
+			c.Description == "Test Description" &&
+			c.ProjectId == "project1" &&
+			c.Secret != "" // Secret should be generated
+	})).Return(nil)
+
+	err := service.Create(ctx, client)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, client.Secret) // Secret should be generated
+	mockStore.AssertExpectations(t)
+}
+
+func TestService_Create_With_ServiceAccountEmail_Success(t *testing.T) {
+	mockStore := &MockStore{}
+	mockProjectService := &services.MockProjectService{}
+	mockAuthService := &services.MockAuthProviderService{}
+	mockUserService := &services.MockUserService{}
+	service := NewService(mockStore, mockProjectService, mockAuthService, mockUserService)
+
+	testUser := &sdk.User{Id: "user1", Name: "Test User"}
+	metadata := sdk.Metadata{
+		User:       testUser,
+		ProjectIds: []string{"project1", "project2"},
+	}
+	ctx := middlewares.AddMetadata(context.Background(), metadata)
+
+	client := &sdk.Client{
+		Name:                "Test Client",
+		Description:         "Test Description",
+		ProjectId:           "project1",
+		ServiceAccountEmail: "test@test.com",
 	}
 
 	// We expect the store to be called with the client having a generated secret
@@ -794,7 +829,7 @@ func TestService_RegenerateSecret(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, clientId, result.Id)
-	assert.NotEmpty(t, result.Secret) // New secret should be generated
+	assert.NotEmpty(t, result.Secret)                    // New secret should be generated
 	assert.NotEqual(t, "oldHashedSecret", result.Secret) // Should be different
 
 	mockStore.AssertExpectations(t)
@@ -850,7 +885,6 @@ func TestService_RegenerateSecret_UpdateError(t *testing.T) {
 
 	mockStore.AssertExpectations(t)
 }
-
 
 func TestService_Create_NoUserInContext(t *testing.T) {
 	mockStore := &MockStore{}
@@ -934,10 +968,10 @@ func TestService_Create_WithAuthProvider(t *testing.T) {
 	ctx := middlewares.AddMetadata(context.Background(), metadata)
 
 	client := &sdk.Client{
-		Name:                    "Test Client",
-		Description:             "Test Description",
-		ProjectId:               "project1",
-		DefaultAuthProviderId:   "provider1",
+		Name:                  "Test Client",
+		Description:           "Test Description",
+		ProjectId:             "project1",
+		DefaultAuthProviderId: "provider1",
 	}
 
 	mockAuthService.On("Get", ctx, "provider1", true).Return(&sdk.AuthProvider{Id: "provider1"}, nil)
@@ -964,10 +998,10 @@ func TestService_Create_AuthProviderNotFound(t *testing.T) {
 	ctx := createContextWithProjects([]string{"project1"})
 
 	client := &sdk.Client{
-		Name:                    "Test Client",
-		Description:             "Test Description",
-		ProjectId:               "project1",
-		DefaultAuthProviderId:   "provider1",
+		Name:                  "Test Client",
+		Description:           "Test Description",
+		ProjectId:             "project1",
+		DefaultAuthProviderId: "provider1",
 	}
 
 	mockAuthService.On("Get", ctx, "provider1", true).Return((*sdk.AuthProvider)(nil), sdk.ErrAuthProviderNotFound)

--- a/services/client/service_impl_test.go
+++ b/services/client/service_impl_test.go
@@ -908,10 +908,10 @@ func TestService_Create_NoUserInContext(t *testing.T) {
 
 	// We expect the store to be called with the client having a generated secret
 	mockStore.On("Create", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)
-	mockUserService.On("Create", ctx, mock.MatchedBy(func(u *sdk.User) bool {
-		return u.CreatedBy == "system" // Should use "system" as creator
-	})).Return(nil)
-	mockStore.On("Update", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)
+	// mockUserService.On("Create", ctx, mock.MatchedBy(func(u *sdk.User) bool {
+	// 	return u.CreatedBy == "system" // Should use "system" as creator
+	// })).Return(nil)
+	// mockStore.On("Update", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)
 
 	err := service.Create(ctx, client)
 
@@ -936,9 +936,10 @@ func TestService_Create_ServiceAccountUpdateError(t *testing.T) {
 	ctx := middlewares.AddMetadata(context.Background(), metadata)
 
 	client := &sdk.Client{
-		Name:        "Test Client",
-		Description: "Test Description",
-		ProjectId:   "project1",
+		ServiceAccountEmail: "test@yesy.com",
+		Name:                "Test Client",
+		Description:         "Test Description",
+		ProjectId:           "project1",
 	}
 
 	mockStore.On("Create", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)

--- a/services/client/service_impl_test.go
+++ b/services/client/service_impl_test.go
@@ -977,8 +977,6 @@ func TestService_Create_WithAuthProvider(t *testing.T) {
 
 	mockAuthService.On("Get", ctx, "provider1", true).Return(&sdk.AuthProvider{Id: "provider1"}, nil)
 	mockStore.On("Create", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)
-	mockUserService.On("Create", ctx, mock.AnythingOfType("*sdk.User")).Return(nil)
-	mockStore.On("Update", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)
 
 	err := service.Create(ctx, client)
 
@@ -1049,9 +1047,10 @@ func TestService_Create_UserCreateError(t *testing.T) {
 	ctx := middlewares.AddMetadata(context.Background(), metadata)
 
 	client := &sdk.Client{
-		Name:        "Test Client",
-		Description: "Test Description",
-		ProjectId:   "project1",
+		Name:                "Test Client",
+		Description:         "Test Description",
+		ProjectId:           "project1",
+		ServiceAccountEmail: "test@yetr.com",
 	}
 
 	mockStore.On("Create", ctx, mock.AnythingOfType("*sdk.Client")).Return(nil)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service account linking now only runs when a valid service account email is provided.
  * Client secret handling tightened: plain secret exists only during creation and is hashed before storage; event behavior preserved.

* **Tests**
  * Added tests covering client creation with a service account email and secret generation/verification.
  * Updated tests to match revised creation flow and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->