### PR TITLE
fix: short-circuit no-op resource adds on role and user

### DIFF
--- a/services/role/service_impl.go
+++ b/services/role/service_impl.go
@@ -48,6 +48,12 @@ func (s *service) AddResource(ctx context.Context, roleId string, resource sdk.R
 	if err != nil {
 		return err
 	}
+	// no-op if the role already has an identical entry for this resource
+	// key; this prevents spurious EventRoleUpdated emissions that fan out
+	// to every user with the role
+	if existing, ok := role.Resources[resource.Key]; ok && existing == resource {
+		return nil
+	}
 	if len(role.Resources) == 0 {
 		role.Resources = map[string]sdk.Resources{}
 	}

--- a/services/role/service_impl_test.go
+++ b/services/role/service_impl_test.go
@@ -504,6 +504,50 @@ func TestService_AddResource(t *testing.T) {
 		assert.Contains(t, err.Error(), "update failed")
 		mockStore.AssertExpectations(t)
 	})
+
+	t.Run("no-op_when_resource_already_present", func(t *testing.T) {
+		mockStore := &MockStore{}
+		service := NewService(mockStore)
+		ctx := context.Background()
+
+		resource := sdk.Resources{
+			Id:   "resource1",
+			Key:  "users",
+			Name: "Users Resource",
+		}
+
+		existingRole := &sdk.Role{
+			Id:        "role1",
+			Name:      "Test Role",
+			ProjectId: "project1",
+			Enabled:   true,
+			Resources: map[string]sdk.Resources{
+				"users": resource,
+			},
+		}
+
+		// subscribe to assert no EventRoleUpdated emission
+		sub := &roleEventRecorder{}
+		service.Subscribe(goiamuniverse.EventRoleUpdated, sub)
+
+		mockStore.On("GetById", ctx, "role1").Return(existingRole, nil)
+		// Update must NOT be called - no mock registered
+
+		err := service.AddResource(ctx, "role1", resource)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, sub.calls, "expected no EventRoleUpdated when resource is already present")
+		mockStore.AssertExpectations(t)
+	})
+}
+
+// roleEventRecorder counts EventRoleUpdated emissions for assertion in tests.
+type roleEventRecorder struct {
+	calls int
+}
+
+func (r *roleEventRecorder) HandleEvent(event utils.Event[sdk.Role]) {
+	r.calls++
 }
 
 func TestService_Emit(t *testing.T) {

--- a/services/user/service_impl.go
+++ b/services/user/service_impl.go
@@ -133,6 +133,14 @@ func (s *service) AddResourceToUser(ctx context.Context, userId string, request 
 		return err
 	}
 
+	// no-op if the resource is already present on the user with this
+	// policy id; this prevents spurious EventUserUpdated emissions and
+	// breaks the cascade triggered by the add_resources_to_* system
+	// policies when a resource is created
+	if existing, ok := usr.Resources[request.Key]; ok && existing.PolicyIds[request.PolicyId] {
+		return nil
+	}
+
 	addResourceToUserObj(usr, request)
 
 	// Update user in the database

--- a/services/user/service_impl_test.go
+++ b/services/user/service_impl_test.go
@@ -688,10 +688,10 @@ func TestAddResourceToUser(t *testing.T) {
 	ctx := createContextWithMetadata()
 	svc, mockStore, _ := setupUserService()
 
-	testUser := createTestUser()
 	resourceRequest := sdk.AddUserResourceRequest{
-		Key:  "resource-key",
-		Name: "Resource Name",
+		PolicyId: "policy-1",
+		Key:      "resource-key",
+		Name:     "Resource Name",
 	}
 
 	tests := []struct {
@@ -706,7 +706,7 @@ func TestAddResourceToUser(t *testing.T) {
 			userId:  "user-123",
 			request: resourceRequest,
 			setupMocks: func() {
-				mockStore.On("GetById", ctx, "user-123").Return(testUser, nil)
+				mockStore.On("GetById", ctx, "user-123").Return(createTestUser(), nil)
 				mockStore.On("Update", ctx, mock.AnythingOfType("*sdk.User")).Return(nil)
 			},
 		},
@@ -724,10 +724,25 @@ func TestAddResourceToUser(t *testing.T) {
 			userId:  "user-123",
 			request: resourceRequest,
 			setupMocks: func() {
-				mockStore.On("GetById", ctx, "user-123").Return(testUser, nil)
+				mockStore.On("GetById", ctx, "user-123").Return(createTestUser(), nil)
 				mockStore.On("Update", ctx, mock.AnythingOfType("*sdk.User")).Return(errors.New("database error"))
 			},
 			expectedError: "failed to update user",
+		},
+		{
+			name:    "skip - resource already present with same policy",
+			userId:  "user-123",
+			request: resourceRequest,
+			setupMocks: func() {
+				userWithResource := createTestUser()
+				userWithResource.Resources["resource-key"] = sdk.UserResource{
+					Key:       "resource-key",
+					Name:      "Resource Name",
+					PolicyIds: map[string]bool{"policy-1": true},
+				}
+				mockStore.On("GetById", ctx, "user-123").Return(userWithResource, nil)
+				// Update must NOT be called
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes #48

role.AddResource and user.AddResourceToUser always persisted and emitted an event even when the incoming resource was already present. When a user has both add_resources_to_user and add_resources_to_role system policies, creating a resource produced a redundant EventRoleUpdated that fanned out to every user with the role via user.HandleEvent, causing unnecessary writes and cascaded EventUserUpdated events.

Skip the Update+Emit at the source when the state would not actually change. Adds subtests asserting no store write and no event emission on the no-op path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved efficiency of resource management by preventing unnecessary database updates and redundant event emissions during resource addition operations. When a resource already exists with matching properties, the system now performs an early return to skip the update process. This optimization applies to both role and user resource management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->